### PR TITLE
Implemented support for Events

### DIFF
--- a/nbkode/core.py
+++ b/nbkode/core.py
@@ -328,7 +328,7 @@ class Solver(ABC, metaclass=MetaSolver):
         ValueError
             One of the timepoints provided is outside the valid range.
         """
-        return self.run_events(t, None)
+        return self.run_events(t, None)[:2]
 
     def run_events(
         self,

--- a/nbkode/core.py
+++ b/nbkode/core.py
@@ -421,7 +421,7 @@ class Solver(ABC, metaclass=MetaSolver):
         ValueError
             One of the timepoints provided is outside the valid range.
         """
-        t = np.atleast_1d(t)
+        t = np.atleast_1d(t).astype(np.float64)
 
         is_t_sorted = t.size == 1 or np.all(t[:-1] <= t[1:])
 

--- a/nbkode/core.py
+++ b/nbkode/core.py
@@ -12,9 +12,10 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, ABCMeta, abstractmethod
 from numbers import Real
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Iterable, Optional, Tuple, Union
 
 import numpy as np
 from scipy.integrate._ivp.common import (
@@ -23,6 +24,7 @@ from scipy.integrate._ivp.common import (
     validate_tol,
 )
 
+from . import event_handler
 from .buffer import AlignedBuffer
 from .nbcompat import is_jitted, numba
 from .util import CaseInsensitiveDict
@@ -370,6 +372,119 @@ class Solver(ABC, metaclass=MetaSolver):
         ondx = np.argsort(ndx)
         return ts[ondx], ys[ondx]
 
+    def run_events(
+        self, t: Union[Real, np.ndarray], events: Union[Callable, Iterable[Callable]]
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Integrates the ODE interpolating at each of the timepoints `t`.
+
+        (events follows the SciPy `solve_ivp` API)
+
+        Parameters
+        ----------
+        t : float or array-like
+        events : callable, or list of callables (length N)
+            Events to track. If None (default), no events will be tracked.
+            Each event occurs at the zeros of a continuous function of time and
+            state. Each function must have the signature ``event(t, y)`` and return
+            a float. The solver will find an accurate value of `t` at which
+            ``event(t, y(t)) = 0`` using a root-finding algorithm. By default, all
+            zeros will be found. The solver looks for a sign change over each step,
+            so if multiple zero crossings occur within one step, events may be
+            missed. Additionally each `event` function might have the following
+            attributes:
+                terminal: bool, optional
+                    Whether to terminate integration if this event occurs.
+                    Implicitly False if not assigned.
+                direction: float, optional
+                    Direction of a zero crossing. If `direction` is positive,
+                    `event` will only trigger when going from negative to positive,
+                    and vice versa if `direction` is negative. If 0, then either
+                    direction will trigger event. Implicitly 0 if not assigned.
+            You can assign attributes like ``event.terminal = True`` to any
+            function in Python.
+
+        Returns
+        -------
+        t : ndarray, shape (n_points,)
+            Time points.
+        y : ndarray, shape (n, n_points)
+            Values of the solution at `t`.
+        t_events : list of ndarray (length N)
+            Contains for each event type a list of arrays at which an event of
+            that type event was detected. Empty list if no `events`.
+        y_events : list of ndarray (length N)
+            For each value of `t_events`, the corresponding value of the solution.
+            Empty list if no `events`.
+
+        Raises
+        ------
+        ValueError
+            One of the timepoints provided is outside the valid range.
+        """
+        t = np.atleast_1d(t)
+
+        is_t_sorted = t.size == 1 or np.all(t[:-1] <= t[1:])
+
+        if not is_t_sorted:
+            ndx = np.argsort(t)
+            t = t[ndx]
+
+        if t[0] < self.cache.ts[0]:
+            raise ValueError(
+                f"Cannot interpolate at t={t[0]} as it is smaller "
+                f"than the current smallest value in history ({self.cache.ts[0]})"
+            )
+
+        self._check_time(np.max(t))
+
+        to_interpolate = t <= self.t
+        is_to_interpolate = np.any(to_interpolate)
+        if is_to_interpolate:
+            t_old = t[to_interpolate]
+            y_old = np.asarray([self.interpolate(_t) for _t in t_old])
+            t_to_run = t[np.logical_not(to_interpolate)]
+        else:
+            t_to_run = t
+
+        # t_bound will not be reached a it due to validation in _check_time
+        if events:
+            eh = event_handler.build_handler(events, self.t, self.y)
+            ts, ys, scon = self._run_eval_events(
+                self.t_bound,
+                t_to_run,
+                self._step,
+                eh,
+                self._interpolate,
+                *self._step_args,
+            )
+
+            # We cast here to a Python List to avoid exposing a Numbatype
+            t_events = [list(event.t) for event in eh.events]
+            y_events = [list(event.y) for event in eh.events]
+        else:
+            ts, ys, scon = self._run_eval(
+                self.t_bound,
+                t_to_run,
+                self._step,
+                self._interpolate,
+                *self._step_args,
+            )
+            t_events = []
+            y_events = []
+
+        if is_to_interpolate:
+            ts = np.concatenate((t_old, ts))
+            ys = np.concatenate((y_old, ys))
+
+            if events:
+                warnings.warning("Events for past events are not implemented yet.")
+
+        if is_t_sorted:
+            return ts, ys, t_events, y_events
+
+        ondx = np.argsort(ndx)
+        return ts[ondx], ys[ondx], t_events, y_events
+
     def interpolate(self, t: float) -> float:
         """Interpolate solution at t.
 
@@ -530,6 +645,32 @@ class Solver(ABC, metaclass=MetaSolver):
         for ndx, ti in enumerate(t_eval):
             while cache.t < ti:
                 if not step(t_bound, rhs, cache, *args):
+                    return t_eval[:ndx], y_out[:ndx], True
+            y_out[ndx] = interpolate(ti, rhs, cache, *args)
+
+        return t_eval, y_out, False
+
+    @staticmethod
+    @numba.njit
+    def _run_eval_events(
+        t_bound: float,
+        t_eval: np.ndarray,
+        step,
+        event_handler: event_handler.EventHandler,
+        interpolate,
+        rhs,
+        cache,
+        *args,
+    ) -> tuple[np.ndarray, np.ndarray, bool]:
+        """Run up to t, evaluating y at given t and return (t, y) as arrays."""
+
+        y_out = np.empty((t_eval.size, cache.y.size))
+
+        for ndx, ti in enumerate(t_eval):
+            while cache.t < ti:
+                if not step(t_bound, rhs, cache, *args):
+                    return t_eval[:ndx], y_out[:ndx], True
+                if event_handler.evaluate(interpolate, rhs, cache, *args):
                     return t_eval[:ndx], y_out[:ndx], True
             y_out[ndx] = interpolate(ti, rhs, cache, *args)
 

--- a/nbkode/core.py
+++ b/nbkode/core.py
@@ -631,7 +631,9 @@ class Solver(ABC, metaclass=MetaSolver):
                 if not step(t_bound, rhs, cache, *args):
                     return t_eval[:ndx], y_out[:ndx], True
                 if event_handler.evaluate(interpolate, rhs, cache, *args):
-                    return t_eval[:ndx], y_out[:ndx], True
+                    # Append termination value.
+                    t_eval[ndx], y_out[ndx] = event_handler.last_event
+                    return t_eval[: ndx + 1], y_out[: ndx + 1], True
             y_out[ndx] = interpolate(ti, rhs, cache, *args)
 
         return t_eval, y_out, False

--- a/nbkode/event_handler.py
+++ b/nbkode/event_handler.py
@@ -169,7 +169,7 @@ class Event:
     def last_event(self):
         if self.t:
             return self.t[-1], self.y[-1]
-        return np.nan, np.nan
+        return np.nan, np.empty(0) * np.nan
 
 
 if NO_NUMBA:
@@ -177,7 +177,10 @@ if NO_NUMBA:
 else:
     _EVENT_HANDLER_SPEC = [
         ("events", numba.types.ListType(Event.class_type.instance_type)),
-        ("last_event", numba.types.Tuple((numba.types.float64, numba.types.float64))),
+        (
+            "last_event",
+            numba.types.Tuple((numba.types.float64, numba.types.float64[:])),
+        ),
     ]
 
 
@@ -195,7 +198,7 @@ class EventHandler:
 
     def __init__(self, events):
         self.events = events
-        self.last_event = np.nan, np.nan
+        self.last_event = np.nan, np.empty(0) * np.nan
 
     def evaluate(self, interpolate, rhs, cache, *args):
         """

--- a/nbkode/event_handler.py
+++ b/nbkode/event_handler.py
@@ -1,0 +1,246 @@
+"""
+    nbkode.events
+    ~~~~~~~~~~~~
+
+    Methods for dealing with events.
+
+    Adapted from: https://github.com/scipy/scipy/blob/v1.5.4/scipy/integrate/_ivp/ivp.py
+
+    :copyright: 2020 by nbkode Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+
+from typing import Callable, Iterable
+
+import numpy as np
+from numpy import ndarray
+
+from .nbcompat import NO_NUMBA, is_jitted, numba, zeros
+
+
+@numba.njit()
+def _dummy_event(t, y):
+    return y[0]
+
+
+if NO_NUMBA:
+    TypedList = list
+else:
+    TypedList = numba.typed.List
+    _event_type = numba.types.float64(numba.types.float64, numba.types.float64[:])
+
+
+@numba.njit()
+def event_at_sol(t, event, interpolate, rhs, cache, *args):
+    """Helper function to find the root for the event function along the solution.
+
+    Parameters
+    ----------
+    t : float
+        timepoint
+    event : callable
+        jitted event function.
+    interpolate : callable
+        jitted interpolation function of the solution
+    rhs : callable
+        right hand side of the dynamical system.
+    cache : AlignedBuffer
+        cache of the solver.
+    args
+        extra arguments required for the interpolation function.
+
+    Returns
+    -------
+    float
+
+    """
+    return event(t, interpolate(t, rhs, cache, *args))
+
+
+# TODO: Remove this UGLY HACK
+@numba.njit()
+def _get_tl(val):
+    """Helper function to create typed lists. Should be removed when
+    we can make empty list to work.
+    """
+    out = TypedList()
+    out.append(val)
+    return out
+
+
+@numba.njit()
+def _empty_list(val):
+    """Helper function to create typed lists. Should be removed when
+    we can make empty list to work.
+    """
+    out = _get_tl(val)
+    out.pop()
+    return out
+
+
+if NO_NUMBA:
+    _EVENT_SPEC = None
+else:
+    _EVENT_SPEC = [
+        ("func", _event_type.as_type()),
+        ("is_terminal", numba.bool_),
+        ("direction", numba.int_),
+        ("last_t", numba.float64),
+        ("last_value", numba.float64),
+        ("t", numba.types.ListType(numba.float64)),
+        ("y", numba.types.ListType(numba.float64[::1])),
+    ]
+
+
+@numba.jitclass(_EVENT_SPEC)
+class Event:
+    """Helper class to deal with event.
+
+    An event occurs at the zeros of a continuous function of time and state.
+
+    Parameters
+    ----------
+    func : callable
+        jitted function to calculate the event function.
+    terminal: bool
+        Whether to terminate integration if this event occurs.
+    direction: int
+        Direction of a zero crossing. If `direction` is positive,
+        `event` will only trigger when going from negative to positive,
+        and vice versa if `direction` is negative. If 0, then either
+        direction will trigger event.
+    init_t
+    init_value
+
+    Attributes
+    ----------
+    t : numba typed list of Event (length N)
+    y : numba typed list of Event (length N)
+    """
+
+    def __init__(self, func, is_terminal, direction, init_t, init_y):
+        self.func = func
+        self.is_terminal = is_terminal
+        self.direction = direction
+        self.last_t = init_t
+        self.last_value = func(init_t, init_y)
+
+        self.t = _empty_list(init_t)
+        self.y = _empty_list(init_y)
+
+    def evaluate(self, interpolate, rhs, cache, *args):
+        t = cache.t
+        y = cache.y
+
+        value = self.func(t, y)
+
+        up = (self.last_value <= 0.0) & (value >= 0.0)
+        down = (self.last_value >= 0.0) & (value <= 0.0)
+        either = up | down
+
+        trigger = (
+            up & (self.direction > 0)
+            | down & (self.direction < 0)
+            | either & (self.direction == 0)
+        )
+
+        if trigger:
+            if value == 0:
+                root = t
+            else:
+                root = zeros.bisect(
+                    event_at_sol,
+                    self.last_t,
+                    t,
+                    args=(self.func, interpolate, rhs, cache, *args),
+                )
+
+            # This is required to avoid duplicates
+            if not (self.t and self.t[-1] == root):
+                self.t.append(root)
+                self.y.append(interpolate(root, rhs, cache, *args))
+
+        self.last_t = t
+        self.last_value = value
+
+        return trigger and self.is_terminal
+
+
+if NO_NUMBA:
+    _event = None
+    _EVENT_HANDLER_SPEC = None
+else:
+    _event = Event(_dummy_event, True, 1, 0.0, np.zeros(0, dtype=np.float64))
+    _EVENT_HANDLER_SPEC = [
+        ("events", numba.types.ListType(_event._numba_type_)),
+    ]
+
+
+@numba.jitclass(_EVENT_HANDLER_SPEC)
+class EventHandler:
+    """Helper class to deal with multiple events.
+
+    N is the number of events to be tracked.
+
+    Parameters
+    ----------
+    events : numba typed list of Event (length N)
+
+    """
+
+    def __init__(self, events):
+        self.events = events
+
+    def evaluate(self, interpolate, rhs, cache, *args):
+        """
+        Parameters
+        ----------
+        interpolate : callable
+            interpolator function.
+        rhs : callable
+            Right-hand side of the system. The calling signature is ``fun(t, y)``.
+            Here ``t`` is a scalar, and the ndarray ``y`` hasna shape (n,);
+            then ``fun`` must return array_like with shape (n,).
+        cache : AlignedBuffer
+        args
+            extra arguments provided to interpolate.
+
+        Returns
+        -------
+        bool
+            True if it should terminate.
+        """
+
+        terminate = False
+        for ndx, event in enumerate(self.events):
+            terminate = terminate or event.evaluate(interpolate, rhs, cache, *args)
+
+        return terminate
+
+
+def build_handler(events: Iterable[Callable], t: float, y: ndarray) -> EventHandler:
+    """Standardize event functions and extract is_terminal and direction."""
+
+    if callable(events):
+        events = (events,)
+
+    evs = _empty_list(_event)
+
+    if events is not None:
+        for ndx, event in enumerate(events):
+            try:
+                is_terminal = event.terminal
+            except AttributeError:
+                is_terminal = False
+
+            try:
+                direction = int(np.sign(event.direction))
+            except AttributeError:
+                direction = 0
+
+            if not is_jitted(event):
+                event = numba.njit()(event)
+
+            evs.append(Event(event, is_terminal, direction, t, y))
+
+    return EventHandler(evs)

--- a/nbkode/nbcompat/__init__.py
+++ b/nbkode/nbcompat/__init__.py
@@ -15,7 +15,7 @@
 """
 
 from .common import clip, isclose
-from .nb_to_import import is_jitted, numba
+from .nb_to_import import NO_NUMBA, is_jitted, numba
 from .zeros import j_newton, newton, newton_hd
 
 __all__ = ["clip", "isclose", "j_newton", "newton", "numba", "newton_hd", "is_jitted"]

--- a/nbkode/nbcompat/nb_to_import.py
+++ b/nbkode/nbcompat/nb_to_import.py
@@ -19,9 +19,12 @@ if os.environ.get("NBKODE_NONUMBA", 0):
     def is_jitted(func):
         return True
 
+    NO_NUMBA = True
 
 else:
     import numba  # noqa: F401
     from numba.extending import is_jitted  # noqa: F401
 
     numba.jitclass = numba.experimental.jitclass
+
+    NO_NUMBA = False

--- a/nbkode/nbcompat/numbasub.py
+++ b/nbkode/nbcompat/numbasub.py
@@ -43,6 +43,7 @@ jit = __noop
 jitclass = __noop
 njit = __noop
 vectorize = __noop
+typeof = __noop
 
 
 class WithGetItem:

--- a/nbkode/nbcompat/zeros.py
+++ b/nbkode/nbcompat/zeros.py
@@ -500,3 +500,31 @@ def newton_hd(
     if flag is not NewtonEnum.OK:
         raise RuntimeError
     return y
+
+
+@numba.njit()
+def bisect(fun, left, right, tol=1.48e-8, maxiter=50, rtol=0.0, args=()):
+    if not left < right:
+        raise ValueError("In bisect, 'left' must be smaller than 'rigth'.")
+    yl = fun(left, *args)
+    if yl == 0:
+        return left
+    yr = fun(right, *args)
+    if yr == 0:
+        return right
+    if not yl * yr < 0:
+        raise ValueError(
+            "In bisect, 'fun(left, *args)' must have and opposite sign to 'fun(right, *args)'."
+        )
+
+    for _ in range(maxiter):
+        mid = (left + right) / 2
+        ym = fun(mid, *args)
+        if isclose(ym, 0, rtol=rtol, atol=tol):
+            break
+        if np.sign(ym) == np.sign(yl):
+            left, yl = mid, ym
+        else:
+            right, yr = mid, ym
+
+    return mid


### PR DESCRIPTION
See #13 

A few comments:
- The implementation is inspired by SciPy but has been reorganized for clarity.
- We use a simple and newly incorporated into nbkode bisection method instead of `brentq` as it is not avaible for numba (yet)
- There are two classes: `Event` and `EventHandler` (which maybe is better to rename to `MultiEvent`). As they both share the same API, it might be good to avoid `EventHandler` when a single event is tracked.
- The examples (see below) is taken from the SciPy docs, but it uses `AdamsBashforth1` instead of `RungeKutta45`. To yield good results with `RungeKutta45` we will need to implement the proper interpolator.
- I think the SciPy implementation appends to `t` the termination time if triggered by an event. If that is the case, I think we should do it.
- There are no tests yet.

``` python
import numpy as np


def upward_cannon(t, y):
    return np.asarray([y[1], -0.5])

def hit_ground(t, y):
    return y[0]

def apex(t, y):
    return y[1]

hit_ground.terminal = True
hit_ground.direction = -1

step = .11

import nbkode

print('\nrun')
sol = nbkode.AdamsBashforth1(upward_cannon, 0., [0., 10.], h=step)
t, y = sol.run(100)

print(t)
print(y)

print('\nrun_events empty')
sol = nbkode.AdamsBashforth1(upward_cannon, 0., [0., 10.], h=step)
t, y, t_events, y_events = sol.run_events(100, events=())

print(t)
print(y)
print(t_events)
print(y_events)

print('\nhit ground')
sol = nbkode.AdamsBashforth1(upward_cannon, 0., [0., 10.], h=step)
t, y, t_events, y_events = sol.run_events(100, events=hit_ground)

print(t)
print(y)
print(t_events)
print(y_events)

print('\nhit ground and apex')
sol = nbkode.AdamsBashforth1(upward_cannon, 0., [0., 10.], h=step)
t, y, t_events, y_events = sol.run_events(100, events=(hit_ground, apex))

print(t)
print(y)
print(t_events)
print(y_events)

```