### PR TITLE
Documentation fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,5 +115,5 @@ see CHANGES_
 .. _`Numba`: https://numba.pydata.org/
 .. _`pytest`: https://docs.pytest.org/
 .. _`airspeed velocity`: https://asv.readthedocs.io
-.. _`AUTHORS`: https://github.com/hgrecco/numbakit-ode/blob/master/AUTHORS
-.. _`CHANGES`: https://github.com/hgrecco/numbakit-ode/blob/master/CHANGES
+.. _`AUTHORS`: https://github.com/hgrecco/numbakit-ode/blob/main/AUTHORS
+.. _`CHANGES`: https://github.com/hgrecco/numbakit-ode/blob/main/CHANGES

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,11 @@ or utilizing conda, with the conda-forge channel (*soon*):
 and then simply enjoy it!
 
 
+Documentation
+-------------
+The documentation can be found at https://numbakit-ode.readthedocs.io/en/latest/
+
+
 Design principles
 -----------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -7,15 +7,15 @@ Why the name *numbakit-ode*?
 ----------------------------
 
 We took inspiration from the scikit project, which has been building
-a great ecosystem of science related python packages for a while.
-We think that it would be great to have a group of independent packages
-that levarage Numba for different tasks. **numbakit-ode** aims to speed
+a great ecosystem of science-related python packages for a while.
+We think it would be great to have a group of independent packages
+that leverage Numba for different tasks. **numbakit-ode** aims to speed
 up the integration of ordinary differential equations.
 
 We do not claim ownership of the *numbakit* prefix. On the contrary, we
 would be very happy if other projects use it as well.
 
-While we hope that at some point Numba can support a larger subset
+While we hope that at some point, Numba can support a larger subset
 of Python constructs, we think that there will always be a place
 for numbakit packages as the dynamic nature of Python makes it very
 hard to compile everything.
@@ -36,7 +36,7 @@ Numba cannot (yet) cache the compiled code. But as soon as it can, this overhead
 will be gone.
 
 
-Is integration faster thant SciPy?
+Is integration faster than SciPy?
 ----------------------------------
 
 Yes.
@@ -58,14 +58,14 @@ It is not uncommon to get a 10x speed up. Take a look at the benchmarks_
 How is it possible if the codebase is 100% in Python?
 -----------------------------------------------------
 
-Actually Numba_ does all the heavy work, so the applause should go to
+Actually, Numba_ does all the heavy work, so the applause should go to
 the numba devs. We just make use of it.
 
 
 Why using Numba? Why not c, fortran, <your favorite language>?
 --------------------------------------------------------------
 
-We love Python, and Numba allows you to compile Python code into a machine
+We love Python, and Numba allows you to compile Python code into machine
 code.
 
 
@@ -73,6 +73,6 @@ code.
 .. _`NumPy`: http://www.numpy.org/
 .. _`SciPy Integrate`: https://docs.scipy.org/doc/scipy/reference/integrate.html
 .. _`Numba`: https://numba.pydata.org/
-.. _`benchmarks`: https://hgrecco.github.io/numbakit-ode/
+.. _`benchmarks`: https://github.com/hgrecco/numbakit-ode/tree/main/benchmarks
 
 

--- a/docs/getting.rst
+++ b/docs/getting.rst
@@ -14,7 +14,7 @@ is `conda`:
 
 Then you can install it (or upgrade to the latest version) using pip_::
 
-    $ pip install -U nbkode
+    $ pip install -U numbakit-ode
 
 or with conda, with the conda-forge channel (*soon*):
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,7 +46,7 @@ or filter by characteristics or group name (or names).
 .. doctest:: python
 
     >>> nbkode.get_solvers(implicit=False, fixed_step=True) #doctest: +SKIP
-    >>> nbkode.get_solvers('euler', 'adam-bashforth') #doctest: +SKIP
+    >>> nbkode.get_solvers('euler', 'adams-bashforth') #doctest: +SKIP
 
 
 Quick Installation


### PR DESCRIPTION
This pull request explicitly redirects to `main` rather than `master` for links on README, since the default branch was updated to `main`.

Additionally, I found that running:

```py
nbkode.get_solvers('euler', 'adam-bashforth')
```
from the latest docs gives a key error. It seems that there was a missing `s` in `adam-bashforth`.

**Question**
Since the output after running:

```
>>> nbkode.get_groups()
('Adams-Bashforth', 'Adams-Moulton', 'BDF', 'Euler', 'Runge-Kutta')
```
is the above, would it be a good choice to change as per the below:

```diff
- nbkode.get_solvers('euler', 'adam-bashforth')
+ nbkode.get_solvers('Euler', 'Adams-Bashforth')
```

The latest commit tries to include link to the documentation as per #21 .

Thanks!